### PR TITLE
Fixes/fingerprint length overflow

### DIFF
--- a/lib/Data/Cuid.pm
+++ b/lib/Data/Cuid.pm
@@ -32,7 +32,7 @@ our $VERSION = "0.03";
 # from Math::Base36, but without using Math::BigInt (since only
 # timestamp is the largest int used here )
 sub _encode_base36 {
-    my ( $n, $size ) = ( @_, 1 );
+    my ( $n, $max ) = ( @_, 1 );
 
     my $res = '';
     while ($n) {
@@ -41,10 +41,10 @@ sub _encode_base36 {
         $n = int $n / 36;
     }
 
-    # also return this as a string of exactly $size characters; note
-    # that this means numbers above 36**$size - 1 will be truncated to
-    # $size and be incorrect, unless $size is increased
-    substr sprintf( '%0*s' => $size, scalar reverse $res ), 0 - $size;
+    # also return this as a string of exactly $max characters; note
+    # that this means numbers above 36**$max - 1 will be truncated to
+    # $max and be incorrect, unless $max is increased
+    substr sprintf( '%0*s' => $max, scalar reverse $res ), 0 - $max;
 }
 
 # taken from the NodeJS version of fingerprint

--- a/lib/Data/Cuid.pm
+++ b/lib/Data/Cuid.pm
@@ -96,8 +96,8 @@ Data::Cuid - collision-resistant IDs
 
     use Data::Cuid qw(cuid slug);
 
-    my $id   = cuid();          # cjfphfcxm0000e5i19lls09lovq
-    my $slug = slug();          # y81elxl
+    my $id   = cuid();          # cjg0i57uu0000ng9lwvds8vb3
+    my $slug = slug();          # uv1nlmi
 
 =head1 DESCRIPTION
 

--- a/lib/Data/Cuid.pm
+++ b/lib/Data/Cuid.pm
@@ -43,7 +43,7 @@ sub _encode_base36 {
 
     # also return this as a string of exactly $max characters; note
     # that this means numbers above 36**$max - 1 will be truncated to
-    # $max and be incorrect, unless $max is increased
+    # $max size and be incorrect, unless $max is increased
     substr sprintf( '%0*s' => $max, scalar reverse $res ), 0 - $max;
 }
 

--- a/lib/Data/Cuid.pm
+++ b/lib/Data/Cuid.pm
@@ -32,7 +32,7 @@ our $VERSION = "0.03";
 # from Math::Base36, but without using Math::BigInt (since only
 # timestamp is the largest int used here )
 sub _encode_base36 {
-    my ( $n, $padding ) = ( @_, 1 );
+    my ( $n, $size ) = ( @_, 1 );
 
     my $res = '';
     while ($n) {
@@ -41,7 +41,10 @@ sub _encode_base36 {
         $n = int $n / 36;
     }
 
-    sprintf '%0*s' => $padding, scalar reverse $res;
+    # also return this as a string of exactly $size characters; note
+    # that this means numbers above 36**$size - 1 will be truncated to
+    # $size and be incorrect, unless $size is increased
+    substr sprintf( '%0*s' => $size, scalar reverse $res ), 0 - $size;
 }
 
 # taken from the NodeJS version of fingerprint

--- a/lib/Data/Cuid.pm
+++ b/lib/Data/Cuid.pm
@@ -61,7 +61,10 @@ sub _fingerprint {
 }
 
 sub _random_block { _encode_base36 $cmax * rand() << 0, $size }
-sub _timestamp { _encode_base36 sprintf '%.0f' => Time::HiRes::time * 1000 }
+
+sub _timestamp {
+    _encode_base36 sprintf( '%.0f' => Time::HiRes::time * 1000 ), 8;
+}
 
 sub cuid {
     lc join '' => 'c',

--- a/t/01_cuid.t
+++ b/t/01_cuid.t
@@ -41,13 +41,27 @@ subtest 'package variables' => sub {
 };
 
 subtest 'private functions' => sub {
-    plan tests => 5;
+    plan tests => 6;
 
     ok Data::Cuid::_fingerprint, 'got fingerprint';
+    subtest 'fingerprint size' => sub {
+        plan tests => 2;
+
+        my $fp = Data::Cuid::_fingerprint;
+        note explain $fp;
+        is length $fp, 4, 'fingerprint is at max size';
+
+        local $$ = 36**2 - 1;
+        my $fp_mockpid = Data::Cuid::_fingerprint;
+        note explain $fp_mockpid;
+        is $fp_mockpid, 'ZZ9L', 'fingerprint overflow but still at max size';
+    };
 
     ok Data::Cuid::_random_block, 'got random block';
+    note explain Data::Cuid::_random_block;
 
     ok Data::Cuid::_timestamp, 'got timestamp';
+    note explain Data::Cuid::_timestamp;
 
     my $c = Data::Cuid::_safe_counter;
     ok $c, "counter starts at $c";

--- a/t/01_cuid.t
+++ b/t/01_cuid.t
@@ -54,7 +54,8 @@ subtest 'private functions' => sub {
         local $$ = 36**2 - 1;
         my $fp_mockpid = Data::Cuid::_fingerprint;
         note explain $fp_mockpid;
-        is $fp_mockpid, 'ZZ9L', 'fingerprint overflow but still at max size';
+        is length $fp_mockpid, 4,
+            'fingerprint overflow but still at max size';
     };
 
     ok Data::Cuid::_random_block, 'got random block';

--- a/t/01_cuid.t
+++ b/t/01_cuid.t
@@ -22,7 +22,7 @@ subtest 'basics' => sub {
     note $id;
 
     is $id =~ /^c/, 1, 'cuid starts with "c"';
-    _count_ok $id, 24, 'cuid is at least 24 characters';
+    _count_ok $id, 25, 'cuid is at least 25 characters';
 
     my $slug = Data::Cuid::slug;
     ok $slug, 'slug returns a value';

--- a/t/01_cuid.t
+++ b/t/01_cuid.t
@@ -41,7 +41,21 @@ subtest 'package variables' => sub {
 };
 
 subtest 'private functions' => sub {
-    plan tests => 6;
+    plan tests => 7;
+
+    subtest 'local encode_base36' => sub {
+        plan tests => 3;
+
+        my $n = 1234;
+
+        note explain '$n = ', $n;
+        is Data::Cuid::_encode_base36(1234), 'A',
+            '_encode_base36 of $n is truncated';
+        is Data::Cuid::_encode_base36( 1234, 2 ), 'YA',
+            '_encode_base36 of $n with given size';
+        is Data::Cuid::_encode_base36( 1234, 4 ), '00YA',
+            '_encode_base36 of $n with extra padding';
+    };
 
     ok Data::Cuid::_fingerprint, 'got fingerprint';
     subtest 'fingerprint size' => sub {


### PR DESCRIPTION
This fixes #1 by ensuring that `_encode_base36()` returns a fixed-size result.  Callers of this function are now responsible to specify the size needed; otherwise, a right-anchored truncated value may be returned.